### PR TITLE
feat/ #48-UIScrollView extension 추가 (무한 스크롤 퍼블리셔)

### DIFF
--- a/SMASHING/Global/Extensions/UIScrollView+.swift
+++ b/SMASHING/Global/Extensions/UIScrollView+.swift
@@ -1,0 +1,28 @@
+//
+//  UIScrollView+.swift
+//  SMASHING
+//
+//  Created by 홍준범 on 1/14/26.
+//
+
+import UIKit
+import Combine
+
+extension UIScrollView {
+    var reachedBottomPublisher: AnyPublisher<Void, Never> {
+        return publisher(for: \.contentOffset)
+            .map { [weak self] contentOffset -> Bool in
+                guard let self = self else { return false }
+                
+                let offsetY = contentOffset.y
+                let contentHeight = self.contentSize.height
+                let height = self.frame.size.height
+                
+                return offsetY > contentHeight - height - 100
+            }
+            .removeDuplicates()
+            .filter { $0 }
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #48

---

## 📎 Work Description 
- 무한 스크롤 Combine Publisher 구현
- 무한 스크롤을 사용할 것 같은 UICollectionView 나 UITableView나 UIScrollView를 상속받아서 UIScrollView extension 으로 만들었습니다.
- 화면 끝보다 100pt 이전에 트리거하여 더 부드러운 로딩 경험을 제공하도록 했습니다. (사용자가 스크롤을 멈추지 않아도 미리 다음 페이지 로딩 시작)
- `removeDuplicates()`로 중복 호출 방지

### 주요 동작
1. contentOffset 변화 감지
2. 하단 100pt 도달 시 이벤트 발행
3. 중복 제거 후 Void 이벤트로 변환
```Swift
extension UIScrollView {
    var reachedBottomPublisher: AnyPublisher<Void, Never> {
        return publisher(for: \.contentOffset)
            .map { [weak self] contentOffset -> Bool in
                guard let self = self else { return false }
                
                let offsetY = contentOffset.y
                let contentHeight = self.contentSize.height
                let height = self.frame.size.height
                
                return offsetY > contentHeight - height - 100
            }
            .removeDuplicates()
            .filter { $0 }
            .map { _ in () }
            .eraseToAnyPublisher()
    }
}
```

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.