### PR TITLE
[feat] 보낸요청&받은요청&경기결과 확정전 수락 매칭 API 구현

### DIFF
--- a/SMASHING/Networks/API/MatchingConfirmedAPI.swift
+++ b/SMASHING/Networks/API/MatchingConfirmedAPI.swift
@@ -1,0 +1,55 @@
+//
+//  MatchingConfirmedAPI.swift
+//  SMASHING
+//
+//  Created by Claude on 1/17/26.
+//
+
+import Foundation
+
+import Moya
+import Alamofire
+
+enum MatchingConfirmedAPI {
+    case getConfirmedGameList(snapshotAt: String?, cursor: String?, size: Int?, order: String?)
+}
+
+extension MatchingConfirmedAPI: BaseTargetType {
+
+    var path: String {
+        switch self {
+        case .getConfirmedGameList:
+            return "api/v1/users/me/games/pending-results"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getConfirmedGameList:
+            return .get
+        }
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .getConfirmedGameList(let snapshotAt, let cursor, let size, let order):
+            var parameters: [String: Any] = [:]
+            if let snapshotAt = snapshotAt { parameters["snapshotAt"] = snapshotAt }
+            if let cursor = cursor { parameters["cursor"] = cursor }
+            if let size = size { parameters["size"] = size }
+            if let order = order { parameters["order"] = order }
+            return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        }
+    }
+
+    var headers: [String : String]? {
+        guard let accessToken = KeychainService.get(key: Environment.accessTokenKey) else {
+            return ["Content-Type": "application/json"]
+        }
+
+        return [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(accessToken)"
+        ]
+    }
+}

--- a/SMASHING/Networks/API/ReceiveRequestAPI.swift
+++ b/SMASHING/Networks/API/ReceiveRequestAPI.swift
@@ -1,0 +1,54 @@
+//
+//  ReceiveRequestAPI.swift
+//  SMASHING
+//
+//  Created by JIN on 1/18/26.
+//
+
+import Foundation
+
+import Moya
+import Alamofire
+
+enum ReceiveRequestAPI {
+    case getReceivedRequestList(snapshotAt: String?, cursor: String?, size: Int?)
+}
+
+extension ReceiveRequestAPI: BaseTargetType {
+
+    var path: String {
+        switch self {
+        case .getReceivedRequestList:
+            return "api/v1/users/me/matchings/received"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getReceivedRequestList:
+            return .get
+        }
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .getReceivedRequestList(let snapshotAt, let cursor, let size):
+            var parameters: [String: Any] = [:]
+            if let snapshotAt = snapshotAt { parameters["snapshotAt"] = snapshotAt }
+            if let cursor = cursor { parameters["cursor"] = cursor }
+            if let size = size { parameters["size"] = size }
+            return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        }
+    }
+
+    var headers: [String : String]? {
+        guard let accessToken = KeychainService.get(key: Environment.accessTokenKey) else {
+            return ["Content-Type": "application/json"]
+        }
+
+        return [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(accessToken)"
+        ]
+    }
+}

--- a/SMASHING/Networks/API/SentRequestResultAPI.swift
+++ b/SMASHING/Networks/API/SentRequestResultAPI.swift
@@ -1,0 +1,61 @@
+//
+//  SentRequestResultAPI.swift
+//  SMASHING
+//
+//  Created by JIN on 1/17/26.
+//
+
+import Foundation
+
+import Moya
+import Alamofire
+
+enum SentRequestResultAPI {
+    case getSentRequestList(snapshotAt: String?, cursor: String?, size: Int?)
+    case cancelSentRequest(matchingId: String)
+}
+
+extension SentRequestResultAPI: BaseTargetType {
+
+    var path: String {
+        switch self {
+        case .getSentRequestList:
+            return "api/v1/users/me/matchings/sent"
+        case .cancelSentRequest(let matchingId):
+            return "api/v1/matchings/\(matchingId)"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getSentRequestList:
+            return .get
+        case .cancelSentRequest:
+            return .delete
+        }
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .getSentRequestList(let snapshotAt, let cursor, let size):
+            var parameters: [String: Any] = [:]
+            if let snapshotAt = snapshotAt { parameters["snapshotAt"] = snapshotAt }
+            if let cursor = cursor { parameters["cursor"] = cursor }
+            if let size = size { parameters["size"] = size }
+            return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        case .cancelSentRequest:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        guard let accessToken = KeychainService.get(key: Environment.accessTokenKey) else {
+            return ["Content-Type": "application/json"]
+        }
+        
+        return [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(accessToken)"
+        ]
+    }
+}

--- a/SMASHING/Networks/DTO/MatchingConfirmedDTO.swift
+++ b/SMASHING/Networks/DTO/MatchingConfirmedDTO.swift
@@ -1,0 +1,51 @@
+//
+//  MatchingConfirmedDTO.swift
+//  SMASHING
+//
+//  Created by Claude on 1/17/26.
+//
+
+import Foundation
+
+// MARK: - CursorResponse 
+
+struct MatchingConfirmedCursorResponseDTO: Codable {
+    let snapshotAt: String
+    let results: [MatchingConfirmedGameDTO]
+    let nextCursor: String?
+    let hasNext: Bool
+}
+
+// MARK: - PendingResultAcceptedGameSummary
+
+struct MatchingConfirmedGameDTO: Codable {
+    let gameID: String
+    let resultStatus: String
+    let createdAt: String
+    let opponent: OpponentSummaryDTO
+    let submitAvailableAt: String
+    let remainingSeconds: Int
+    let isSubmitLocked: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case gameID = "gameId"
+        case resultStatus, createdAt, opponent
+        case submitAvailableAt, remainingSeconds, isSubmitLocked
+    }
+}
+
+// MARK: - OpponentSummary
+
+struct OpponentSummaryDTO: Codable {
+    let userID: String
+    let nickname: String
+    let openchatUrl: String?
+    let gender: String
+    let tierCode: String?
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case nickname, openchatUrl, gender
+        case tierCode
+    }
+}

--- a/SMASHING/Networks/DTO/ReceiveRequestDTO.swift
+++ b/SMASHING/Networks/DTO/ReceiveRequestDTO.swift
@@ -1,0 +1,49 @@
+//
+//  ReceiveRequestDTO.swift
+//  SMASHING
+//
+//  Created by JIN on 1/18/26.
+//
+
+import Foundation
+
+// MARK: - CursorResponse
+
+struct ReceiveRequestCursorResponseDTO: Codable {
+    let snapshotAt: String
+    let results: [ReceiveRequestResultDTO]
+    let nextCursor: String?
+    let hasNext: Bool
+}
+
+// MARK: - ReceivedMatchingSummary
+
+struct ReceiveRequestResultDTO: Codable {
+    let matchingID: String
+    let createdAt: String
+    let status: String
+    let requester: RequesterSummaryDTO
+
+    enum CodingKeys: String, CodingKey {
+        case matchingID = "matchingId"
+        case createdAt, status, requester
+    }
+}
+
+// MARK: - RequesterSummary
+
+struct RequesterSummaryDTO: Codable {
+    let userID: String
+    let nickname: String
+    let gender: String
+    let reviewCount: Int
+    let tierCode: String
+    let wins: Int
+    let losses: Int
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case nickname, gender, reviewCount
+        case tierCode, wins, losses
+    }
+}

--- a/SMASHING/Networks/DTO/SentRequestResultDTO.swift
+++ b/SMASHING/Networks/DTO/SentRequestResultDTO.swift
@@ -1,0 +1,49 @@
+//
+//  SentRequestResultDTO.swift
+//  SMASHING
+//
+//  Created by JIN on 1/17/26.
+//
+
+import Foundation
+
+// MARK: - CursorResponse 
+
+struct SentRequestCursorResponseDTO: Codable {
+    let snapshotAt: String
+    let results: [SentRequestResultDTO]
+    let nextCursor: String?
+    let hasNext: Bool
+}
+
+// MARK: - SentMatchingSummaryResponse
+
+struct SentRequestResultDTO: Codable {
+    let matchingID: String
+    let createdAt: String
+    let status: String
+    let receiver: SentRequestReceiverDTO
+
+    enum CodingKeys: String, CodingKey {
+        case matchingID = "matchingId"
+        case createdAt, status, receiver
+    }
+}
+
+// MARK: - ReceiverSummary
+
+struct SentRequestReceiverDTO: Codable {
+    let userID: String
+    let nickname: String
+    let gender: String
+    let reviewCount: Int
+    let tierCode: String
+    let wins: Int
+    let losses: Int
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case nickname, gender, reviewCount
+        case tierCode, wins, losses
+    }
+}

--- a/SMASHING/Networks/Service/MatchingConfirmedService.swift
+++ b/SMASHING/Networks/Service/MatchingConfirmedService.swift
@@ -1,0 +1,117 @@
+//
+//  MatchingConfirmedService.swift
+//  SMASHING
+//
+//  Created by Claude on 1/17/26.
+//
+
+import Foundation
+import Combine
+
+// MARK: - MatchingConfirmedServiceProtocol
+
+protocol MatchingConfirmedServiceProtocol {
+    func getConfirmedGameList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?,
+        order: String?
+    ) -> AnyPublisher<MatchingConfirmedCursorResponseDTO, NetworkError>
+}
+
+// MARK: - MatchingConfirmedService
+
+final class MatchingConfirmedService: MatchingConfirmedServiceProtocol {
+
+    func getConfirmedGameList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?,
+        order: String?
+    ) -> AnyPublisher<MatchingConfirmedCursorResponseDTO, NetworkError> {
+        return NetworkProvider<MatchingConfirmedAPI>
+            .requestPublisher(
+                .getConfirmedGameList(
+                    snapshotAt: snapshotAt,
+                    cursor: cursor,
+                    size: size,
+                    order: order
+                ),
+                type: MatchingConfirmedCursorResponseDTO.self
+            )
+            .map { response in
+                response.data
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - MockMatchingConfirmedService
+
+final class MockMatchingConfirmedService: MatchingConfirmedServiceProtocol {
+
+    func getConfirmedGameList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?,
+        order: String?
+    ) -> AnyPublisher<MatchingConfirmedCursorResponseDTO, NetworkError> {
+        let mockData = MatchingConfirmedCursorResponseDTO(
+            snapshotAt: "2026-01-17T12:00:00+09:00",
+            results: [
+                MatchingConfirmedGameDTO(
+                    gameID: "0P4G1GZ5AF0XG",
+                    resultStatus: "RESULT_REJECTED",
+                    createdAt: "2026-01-17T10:00:00+09:00",
+                    opponent: OpponentSummaryDTO(
+                        userID: "0USER000111227",
+                        nickname: "도윤",
+                        openchatUrl: "https://open.kakao.com/o/example1",
+                        gender: "MALE",
+                        tierCode: "PT1"
+                    ),
+                    submitAvailableAt: "2026-01-17T11:00:00+09:00",
+                    remainingSeconds: 1570,
+                    isSubmitLocked: true
+                ),
+                MatchingConfirmedGameDTO(
+                    gameID: "0P3M3MGSH4MZG",
+                    resultStatus: "WAITING_CONFIRMATION",
+                    createdAt: "2026-01-17T09:30:00+09:00",
+                    opponent: OpponentSummaryDTO(
+                        userID: "0USER000111228",
+                        nickname: "수아",
+                        openchatUrl: "https://open.kakao.com/o/example2",
+                        gender: "FEMALE",
+                        tierCode: "DM1"
+                    ),
+                    submitAvailableAt: "2026-01-17T10:30:00+09:00",
+                    remainingSeconds: 0,
+                    isSubmitLocked: false
+                ),
+                MatchingConfirmedGameDTO(
+                    gameID: "0P2K2KFSG3LYF",
+                    resultStatus: "PENDING_RESULT",
+                    createdAt: "2026-01-17T09:00:00+09:00",
+                    opponent: OpponentSummaryDTO(
+                        userID: "0USER000111229",
+                        nickname: "예준",
+                        openchatUrl: nil,
+                        gender: "MALE",
+                        tierCode: "CH"
+                    ),
+                    submitAvailableAt: "2026-01-17T10:00:00+09:00",
+                    remainingSeconds: 0,
+                    isSubmitLocked: false
+                )
+            ],
+            nextCursor: cursor == nil ? "eyJpZCI6IjBQMksyS0ZTRzNMWUYifQ" : nil,
+            hasNext: cursor == nil
+        )
+
+        return Just(mockData)
+            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .setFailureType(to: NetworkError.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/SMASHING/Networks/Service/ReceiveRequestService.swift
+++ b/SMASHING/Networks/Service/ReceiveRequestService.swift
@@ -1,0 +1,97 @@
+//
+//  ReceiveRequestService.swift
+//  SMASHING
+//
+//  Created by JIN on 1/18/26.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Protocol
+
+protocol ReceiveRequestServiceProtocol {
+    func getReceivedRequestList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?
+    ) -> AnyPublisher<ReceiveRequestCursorResponseDTO, NetworkError>
+}
+
+// MARK: - Service
+
+final class ReceiveRequestService: ReceiveRequestServiceProtocol {
+
+    func getReceivedRequestList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?
+    ) -> AnyPublisher<ReceiveRequestCursorResponseDTO, NetworkError> {
+        return NetworkProvider<ReceiveRequestAPI>
+            .requestPublisher(
+                .getReceivedRequestList(
+                    snapshotAt: snapshotAt,
+                    cursor: cursor,
+                    size: size
+                ),
+                type: ReceiveRequestCursorResponseDTO.self
+            )
+            .map { response in
+                response.data
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Mock Service
+
+final class MockReceiveRequestService: ReceiveRequestServiceProtocol {
+
+    func getReceivedRequestList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?
+    ) -> AnyPublisher<ReceiveRequestCursorResponseDTO, NetworkError> {
+        let mockResults: [ReceiveRequestResultDTO] = [
+            ReceiveRequestResultDTO(
+                matchingID: "0P4ZQSTKAN4ZR",
+                createdAt: "2026-01-12T03:16:31+09:00",
+                status: "REQUESTED",
+                requester: RequesterSummaryDTO(
+                    userID: "0KGHK8KM7TNX6",
+                    nickname: "공공",
+                    gender: "FEMALE",
+                    reviewCount: 2,
+                    tierCode: "BR2",
+                    wins: 2,
+                    losses: 0
+                )
+            ),
+            ReceiveRequestResultDTO(
+                matchingID: "0P4ZQSRGTN4VT",
+                createdAt: "2026-01-12T03:16:30+09:00",
+                status: "REQUESTED",
+                requester: RequesterSummaryDTO(
+                    userID: "0KGHK8KM7TNX6",
+                    nickname: "테니스왕",
+                    gender: "MALE",
+                    reviewCount: 5,
+                    tierCode: "SV1",
+                    wins: 10,
+                    losses: 3
+                )
+            )
+        ]
+
+        let response = ReceiveRequestCursorResponseDTO(
+            snapshotAt: "2026-01-12T05:30:56.649619+09:00",
+            results: mockResults,
+            nextCursor: nil,
+            hasNext: false
+        )
+
+        return Just(response)
+            .setFailureType(to: NetworkError.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/SMASHING/Networks/Service/SentRequestListService.swift
+++ b/SMASHING/Networks/Service/SentRequestListService.swift
@@ -1,0 +1,129 @@
+//
+//  SentRequestListService.swift
+//  SMASHING
+//
+//  Created by JIN on 1/17/26.
+//
+
+import Foundation
+import Combine
+
+// MARK: - SentRequestServiceProtocol
+
+protocol SentRequestServiceProtocol {
+    func getSentRequestList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?
+    ) -> AnyPublisher<SentRequestCursorResponseDTO, NetworkError>
+
+    func cancelSentRequest(matchingId: String) -> AnyPublisher<Void, NetworkError>
+}
+
+// MARK: - SentRequestService
+
+final class SentRequestService: SentRequestServiceProtocol {
+
+    func getSentRequestList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?
+    ) -> AnyPublisher<SentRequestCursorResponseDTO, NetworkError> {
+        return NetworkProvider<SentRequestResultAPI>
+            .requestPublisher(
+                .getSentRequestList(snapshotAt: snapshotAt, cursor: cursor, size: size),
+                type: SentRequestCursorResponseDTO.self
+            )
+            .map { response in
+                response.data
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func cancelSentRequest(matchingId: String) -> AnyPublisher<Void, NetworkError> {
+        return NetworkProvider<SentRequestResultAPI>
+            .requestPublisher(
+                .cancelSentRequest(matchingId: matchingId),
+                type: EmptyResponse.self
+            )
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - EmptyResponse (취소 API 응답용)
+
+struct EmptyResponse: Codable {}
+
+// MARK: - MockSentRequestService
+
+final class MockSentRequestService: SentRequestServiceProtocol {
+
+    func getSentRequestList(
+        snapshotAt: String?,
+        cursor: String?,
+        size: Int?
+    ) -> AnyPublisher<SentRequestCursorResponseDTO, NetworkError> {
+        let mockData = SentRequestCursorResponseDTO(
+            snapshotAt: "2026-01-17T12:00:00+09:00",
+            results: [
+                SentRequestResultDTO(
+                    matchingID: "MATCH001",
+                    createdAt: "2026-01-17T10:00:00+09:00",
+                    status: "REQUESTED",
+                    receiver: SentRequestReceiverDTO(
+                        userID: "0USER000111225",
+                        nickname: "나는다섯글자인간임ㅅㄱ",
+                        gender: "MALE",
+                        reviewCount: 8,
+                        tierCode: "GO1",
+                        wins: 30,
+                        losses: 15
+                    )
+                ),
+                SentRequestResultDTO(
+                    matchingID: "MATCH002",
+                    createdAt: "2026-01-17T09:30:00+09:00",
+                    status: "REQUESTED",
+                    receiver: SentRequestReceiverDTO(
+                        userID: "0USER000111226",
+                        nickname: "하은",
+                        gender: "FEMALE",
+                        reviewCount: 4,
+                        tierCode: "SV2",
+                        wins: 15,
+                        losses: 20
+                    )
+                ),
+                SentRequestResultDTO(
+                    matchingID: "MATCH003",
+                    createdAt: "2026-01-17T09:00:00+09:00",
+                    status: "REQUESTED",
+                    receiver: SentRequestReceiverDTO(
+                        userID: "0USER000111227",
+                        nickname: "스매싱왕",
+                        gender: "MALE",
+                        reviewCount: 15,
+                        tierCode: "DM1",
+                        wins: 50,
+                        losses: 10
+                    )
+                )
+            ],
+            nextCursor: cursor == nil ? "eyJpZCI6Ik1BVENIMDAzIn0" : nil,
+            hasNext: cursor == nil
+        )
+
+        return Just(mockData)
+            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .setFailureType(to: NetworkError.self)
+            .eraseToAnyPublisher()
+    }
+
+    func cancelSentRequest(matchingId: String) -> AnyPublisher<Void, NetworkError> {
+        return Just(())
+            .delay(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .setFailureType(to: NetworkError.self)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #74 

---

## 📎 Work Description 
- SentRequestService SentRequestDTO SentRequestAPI
- ReceiveRequestService ReceiveRequestDTO ReceiveRequestAPI
- MatchingConfirmedService MatchingConfirmedRequestDTO MatchingConfirmedAPI

- 응답형태를 받는 StructDTO 구현 데이터를 호출하는 service객체 구현 Moya 라이브러리를 활용한 Api 타입 구현

- Test를 위한 MockDataService객체 구현

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 확정된 게임 목록 조회 기능 추가 (정렬 및 페이지네이션 지원)
  * 받은 매칭 요청 목록 조회 기능 추가
  * 보낸 매칭 요청 목록 조회 및 취소 기능 추가
  * 모든 요청 목록에서 커서 기반 페이지네이션 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->