### PR TITLE
[feat] String -> Date & Date -> String 구현

### DIFF
--- a/SMASHING/Global/Extensions/Date+.swift
+++ b/SMASHING/Global/Extensions/Date+.swift
@@ -1,0 +1,54 @@
+//
+//  Date+.swift
+//  SMASHING
+//
+//  Created by 이승준 on 1/21/26.
+//
+
+import Foundation
+
+enum DateUtils {
+    static let iso8601Formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+}
+
+extension String {
+    var toDateFromISO8601: Date? {
+        return DateUtils.iso8601Formatter.date(from: self)
+    }
+}
+
+extension Date {
+    func toRelativeString() -> String {
+        let calendar = Calendar.current
+        let now = Date()
+        let components = calendar.dateComponents([.year, .month, .weekOfMonth, .day, .hour, .minute, .second], from: self, to: now)
+        
+        if let year = components.year, year >= 1 {
+            return "\(year)년 전"
+        }
+        if let month = components.month, month >= 1 {
+            return "\(month)달 전"
+        }
+        if let week = components.weekOfMonth, week >= 1 {
+            return "\(week)주일 전"
+        }
+        if let day = components.day, day >= 1 {
+            return "\(day)일 전"
+        }
+        if let hour = components.hour, hour >= 1 {
+            return "\(hour)시간 전"
+        }
+        if let minute = components.minute, minute >= 1 {
+            return "\(minute)분 전"
+        }
+        
+        return "방금 전"
+    }
+}
+

--- a/SMASHING/Presentation/Review/Cell/ReviewCollectionViewCell.swift
+++ b/SMASHING/Presentation/Review/Cell/ReviewCollectionViewCell.swift
@@ -100,7 +100,14 @@ final class ReviewCollectionViewCell: UICollectionViewCell, ReuseIdentifiable {
     
     func configure(_ review :RecentReviewResult) {
         nicknameLabel.text = review.opponentNickname
-        dateLabel.text = review.createdAt
+        dateLabel.text = review.createdAt.toDateFromISO8601?.toRelativeString()
         contentLabel.text = review.content
+        
+        if let date = review.createdAt.toDateFromISO8601 {
+            print("1. 파싱 성공: \(date)")
+            print("2. 상대 시간: \(date.toRelativeString())")
+        } else {
+            print("1. 파싱 실패: 문자열 형식을 다시 확인하세요.")
+        }
     }
 }


### PR DESCRIPTION
## 📌 Related Issue  
- closed #98

---

## 📎 Work Description 

```swift
import Foundation

enum DateUtils {
    static let iso8601Formatter: DateFormatter = {
        let formatter = DateFormatter()
        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
        formatter.locale = Locale(identifier: "en_US_POSIX")
        formatter.timeZone = TimeZone(secondsFromGMT: 0)
        return formatter
    }()
}

extension String {
    var toDateFromISO8601: Date? {
        return DateUtils.iso8601Formatter.date(from: self)
    }
}

extension Date {
    func toRelativeString() -> String {
        let calendar = Calendar.current
        let now = Date()
        let components = calendar.dateComponents([.year, .month, .weekOfMonth, .day, .hour, .minute, .second], from: self, to: now)
        
        if let year = components.year, year >= 1 {
            return "\(year)년 전"
        }
        if let month = components.month, month >= 1 {
            return "\(month)달 전"
        }
        if let week = components.weekOfMonth, week >= 1 {
            return "\(week)주일 전"
        }
        if let day = components.day, day >= 1 {
            return "\(day)일 전"
        }
        if let hour = components.hour, hour >= 1 {
            return "\(hour)시간 전"
        }
        if let minute = components.minute, minute >= 1 {
            return "\(minute)분 전"
        }
        
        return "방금 전"
    }
}
```

---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro |
|:---------:|:--------------:|
| A 기능 |  <img width="192" height="203" alt="Screenshot 2026-01-21 at 6 08 31 PM" src="https://github.com/user-attachments/assets/0c4ad404-6622-4603-bf4a-a867264de2af" /> |


---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 리뷰의 작성 시간이 상대적 시간 형식으로 표시됩니다 (예: "5분 전", "2시간 전", "3일 전"). 시간 단위는 년, 월, 주, 일, 시간, 분 순서로 표시되며, 1분 미만일 경우 "방금 전"으로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->