### PR TITLE
[feat]/#112 매칭 관리 탭, 결과 작성 연결

### DIFF
--- a/SMASHING/Presentation/MatchingManage/Cells/MatchingConfirmedCell.swift
+++ b/SMASHING/Presentation/MatchingManage/Cells/MatchingConfirmedCell.swift
@@ -11,55 +11,55 @@ import SnapKit
 import Then
 
 final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
-
+    
     // MARK: - UI Components
-
+    
     private let containerView = UIView().then {
         $0.backgroundColor = .Background.surface
         $0.layer.cornerRadius = 8
     }
-
+    
     private let profileImageView = UIImageView().then {
         $0.backgroundColor = .Background.canvasReverse
         $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 26
     }
-
+    
     private let nicknameLabel = UILabel().then {
         $0.font = .pretendard(.textSmSb)
         $0.textColor = .Text.primary
     }
-
+    
     private let genderIconImageView = UIImageView().then {
         $0.tintColor = .white
         $0.contentMode = .scaleAspectFit
     }
-
+    
     private let nicknameStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 2
         $0.alignment = .center
     }
-
+    
     private let tierBadgeLabel = UILabel().then {
         $0.font = .pretendard(.captionXsR)
         $0.textAlignment = .center
         $0.layer.cornerRadius = 2
         $0.clipsToBounds = true
     }
-
+    
     private let profileStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 4
         $0.alignment = .center
     }
-
+    
     private lazy var linkIcon = UIImageView().then {
         $0.image = .icLink
         $0.contentMode = .scaleAspectFit
     }
-
+    
     private lazy var kakaoTalkLinkButton = UIButton().then {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.pretendard(.captionXsR),
@@ -72,16 +72,17 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
         )
         $0.setAttributedTitle(attributedString, for: .normal)
     }
-
+    
     private let kakaoLinkStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 4
         $0.alignment = .center
     }
     
-    private let writeResult = UIButton().then {
+    private lazy var writeResult = UIButton().then {
         $0.titleLabel?.font = .pretendard(.textSmM)
         $0.layer.cornerRadius = 4
+        $0.addTarget(self, action: #selector(writeResultButtonDidTap), for: .touchUpInside)
     }
     
     private lazy var closeButton = UIButton().then {
@@ -89,15 +90,15 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
         $0.tintColor = .Text.tertiary
         $0.addTarget(self, action: #selector(closeButtonDidTap), for: .touchUpInside)
     }
-
+    
     // MARK: - Properties
     
     var onCloseTapped: (() -> Void)?
     var onSkipTapped: (() -> Void)?
     var onAcceptTapped: (() -> Void)?
-
+    
     // MARK: - Setup Methods
-
+    
     override func setUI() {
         contentView.addSubview(containerView)
         containerView.addSubviews(
@@ -121,7 +122,7 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
         )
         
     }
-
+    
     override func setLayout() {
         containerView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -140,12 +141,12 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
         genderIconImageView.snp.makeConstraints {
             $0.size.equalTo(20)
         }
-
+        
         tierBadgeLabel.snp.makeConstraints {
             $0.height.equalTo(24)
             $0.width.equalTo(67)
         }
-
+        
         profileImageView.snp.makeConstraints {
             $0.size.equalTo(52)
         }
@@ -158,7 +159,7 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
         linkIcon.snp.makeConstraints {
             $0.size.equalTo(24)
         }
-
+        
         kakaoLinkStackView.snp.makeConstraints {
             $0.top.equalTo(tierBadgeLabel.snp.bottom).offset(8)
             $0.centerX.equalToSuperview()
@@ -170,56 +171,70 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(29)
         }
-
+        
     }
     
     // MARK: - Actions
-
+    
     @objc private func closeButtonDidTap() {
         self.onCloseTapped?()
     }
-
+    
+    @objc private func writeResultButtonDidTap() {
+        self.onAcceptTapped?()
+    }
+    
+    
     // MARK: - Configuration
-
-    func configure(with game: MatchingConfirmedGameDTO) {
+    
+    func configure(with game: MatchingConfirmedGameDTO, myUserId: String) {
         let opponent = game.opponent
         self.nicknameLabel.text = opponent.nickname
         self.genderIconImageView.image = opponent.gender.imageSm
         self.configureTierBadge(tierCode: opponent.tierCode)
-        self.updateWriteResultButton(resultState: game.resultStatus)
+        let isMySubmission = game.latestSubmitterId == myUserId
+        self.updateWriteResultButton(resultState: game.resultStatus, isMySubmission: isMySubmission, isSubmitLocked: game.isSubmitLocked)
     }
-
-    private func updateWriteResultButton(resultState: GameResultStatus) {
+    
+    private func updateWriteResultButton(resultState: GameResultStatus, isMySubmission: Bool, isSubmitLocked: Bool) {
+        let canConfirm = resultState.canConfirm(isMySubmission: isMySubmission)
+        let canSubmit = resultState.canSubmit(isMySubmission: isMySubmission) && !isSubmitLocked
+        let title = resultState.buttonTitle(isMySubmission: isMySubmission)
+        
+        self.writeResult.setTitle(title, for: .normal)
+        self.writeResult.isEnabled = canSubmit || canConfirm
+        
         switch resultState {
         case .resultConfirmed:
-            self.writeResult.setTitle("결과 확인하기", for: .normal)
             self.writeResult.backgroundColor = .Button.backgroundConfirmed
             self.writeResult.setTitleColor(.Text.emphasis, for: .normal)
-            self.writeResult.isEnabled = true
         case .pendingResult:
-            self.writeResult.setTitle("결과 작성하기", for: .normal)
             self.writeResult.setTitleColor(.Text.emphasis, for: .normal)
             self.writeResult.backgroundColor = .Button.backgroundPrimaryActive
-            self.writeResult.isEnabled = true
         case .resultRejected:
-            self.writeResult.setTitle("결과가 반려되었어요!", for: .normal)
-            self.writeResult.backgroundColor = .Button.backgroundRejected
-            self.writeResult.setTitleColor(.Button.textRejected, for: .normal)
-            self.writeResult.isEnabled = false
+            if canSubmit {
+                self.writeResult.backgroundColor = .Button.backgroundPrimaryActive
+                self.writeResult.setTitleColor(.Text.emphasis, for: .normal)
+            } else {
+                self.writeResult.backgroundColor = .Button.backgroundPrimaryDisabled
+                self.writeResult.setTitleColor(.Button.textRejected, for: .normal)
+            }
+            self.writeResult.backgroundColor = .Button.backgroundPrimaryDisabled
+            self.writeResult.setTitleColor(.Button.textPrimaryDisabled, for: .normal)
         case .canceled:
-            self.writeResult.setTitle("매칭 취소 대기중 ", for: .normal)
             self.writeResult.backgroundColor = .Button.backgroundPrimaryDisabled
             self.writeResult.setTitleColor(.Button.textPrimaryDisabled, for: .normal)
-            self.writeResult.isEnabled = false
         case .waitingConfirmation:
-            self.writeResult.setTitle("결과 확인 대기중", for: .normal)
-            self.writeResult.backgroundColor = .Button.backgroundPrimaryDisabled
-            self.writeResult.setTitleColor(.Button.textPrimaryDisabled, for: .normal)
-            self.writeResult.isEnabled = false
-            
+            if canConfirm {
+                self.writeResult.backgroundColor = .Button.backgroundConfirmed
+                self.writeResult.setTitleColor(.Button.backgroundSecondaryActive, for: .normal)
+            } else {
+                self.writeResult.backgroundColor = .Button.backgroundPrimaryDisabled
+                self.writeResult.setTitleColor(.Button.textPrimaryDisabled, for: .normal)
+            }
         }
     }
-
+    
     private func configureTierBadge(tierCode: String?) {
         guard let tierCode = tierCode, let tier = Tier.from(tierCode: tierCode) else {
             self.tierBadgeLabel.text = "Unranked"
@@ -227,7 +242,7 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
             self.tierBadgeLabel.textColor = .Text.primary
             return
         }
-
+        
         self.tierBadgeLabel.text = tier.displayName
         self.tierBadgeLabel.backgroundColor = tier.backgroundColor
         self.tierBadgeLabel.textColor = tier.textColor

--- a/SMASHING/Presentation/MatchingManage/Pages/MatchingConfirmedViewController.swift
+++ b/SMASHING/Presentation/MatchingManage/Pages/MatchingConfirmedViewController.swift
@@ -14,6 +14,14 @@ import Then
 final class MatchingConfirmedViewController: BaseViewController {
 
     // MARK: - Properties
+    
+    private var myUserId: String {
+        return KeychainService.get(key: Environment.userIdKey) ?? ""
+    }
+    
+    private var myNickname: String {
+        return KeychainService.get(key: Environment.nicknameKey) ?? ""
+    }
 
     private let viewModel: MatchingConfirmedViewModel
     private let input = PassthroughSubject<MatchingConfirmedViewModel.Input, Never>()
@@ -69,6 +77,11 @@ final class MatchingConfirmedViewController: BaseViewController {
         super.viewDidLoad()
         bind()
         input.send(.viewDidLoad)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        input.send(.refresh)
     }
 
     // MARK: - Setup Methods
@@ -145,6 +158,39 @@ final class MatchingConfirmedViewController: BaseViewController {
                 self?.input.send(.loadMore)
             }
             .store(in: &cancellables)
+        
+        output.navToMatchResultConfirm
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] gameData in
+                self?.navigateToMatchResultConfirm(gameData: gameData)
+            }
+            .store(in: &cancellables)
+        
+        output.navToMatchResultCreate
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] gameData in
+                self?.showMatchResultCreate(with: gameData)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func navigateToMatchResultConfirm(gameData: MatchingConfirmedGameDTO) {
+        guard let submissionId = gameData.latestSubmissionId else { return }
+        let viewModel = MatchResultConfirmViewModel(
+            gameData: gameData,
+            submissionId: submissionId,
+            myUserId: myUserId
+        )
+        let vc = MatchResultConfirmViewController(viewModel: viewModel)
+        vc.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    private func showMatchResultCreate(with gameData: MatchingConfirmedGameDTO) {
+        let vm = MatchResultCreateViewModel(gameData: gameData, myUserId: myUserId, myNickname: myNickname)
+        let vc = MatchResultCreateViewController(viewModel: vm)
+        vc.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     // MARK: - Actions
@@ -200,10 +246,22 @@ extension MatchingConfirmedViewController: UICollectionViewDataSource {
         }
 
         let game = self.gameList[indexPath.row]
-        cell.configure(with: game)
+        cell.configure(with: game, myUserId: myUserId)
 
         cell.onCloseTapped = { [weak self] in
             self?.closeButtonDidTap(at: indexPath.item)
+        }
+        cell.onAcceptTapped = { [weak self] in
+            guard let self else { return }
+            let isMySubmission = game.latestSubmitterId == self.myUserId
+            let canConfirm = game.resultStatus.canConfirm(isMySubmission: isMySubmission)
+            if canConfirm {
+                // 상대방이 제출한 결과 확인 플로우
+                self.input.send(.matchingResultConfirmButtonTapped(game))
+            } else {
+                // 결과 작성 플로우
+                self.input.send(.matchingResultCreateButtonTapped(game))
+            }
         }
 
         return cell

--- a/SMASHING/Presentation/MatchingManage/ViewModels/MatchingConfirmedViewModel.swift
+++ b/SMASHING/Presentation/MatchingManage/ViewModels/MatchingConfirmedViewModel.swift
@@ -24,10 +24,15 @@ final class MatchingConfirmedViewModel: MatchingConfirmedViewModelProtocol {
         case refresh
         case loadMore
         case closeTapped(index: Int)
+        case matchingResultCreateButtonTapped(MatchingConfirmedGameDTO)
+        case matchingResultConfirmButtonTapped(MatchingConfirmedGameDTO)
+        
     }
 
     struct Output {
         let gameList: AnyPublisher<[MatchingConfirmedGameDTO], Never>
+        let navToMatchResultCreate: AnyPublisher<MatchingConfirmedGameDTO, Never>
+        let navToMatchResultConfirm: AnyPublisher<MatchingConfirmedGameDTO, Never>
         let isLoading: AnyPublisher<Bool, Never>
         let isLoadingMore: AnyPublisher<Bool, Never>
         let errorMessage: AnyPublisher<String, Never>
@@ -35,7 +40,8 @@ final class MatchingConfirmedViewModel: MatchingConfirmedViewModelProtocol {
     }
 
     // MARK: - Private Subjects
-
+    private let navToMatchResultCreateSubject = PassthroughSubject<MatchingConfirmedGameDTO, Never>()
+    private let navToMatchResultConfirmSubject = PassthroughSubject<MatchingConfirmedGameDTO, Never>()
     private let gameListSubject = CurrentValueSubject<[MatchingConfirmedGameDTO], Never>([])
     private let isLoadingSubject = CurrentValueSubject<Bool, Never>(false)
     private let isLoadingMoreSubject = CurrentValueSubject<Bool, Never>(false)
@@ -73,7 +79,10 @@ final class MatchingConfirmedViewModel: MatchingConfirmedViewModelProtocol {
                 switch event {
                 case .viewDidLoad:
                     self.fetchFirstPage()
-
+                case .matchingResultCreateButtonTapped(let gameData):
+                    navToMatchResultCreateSubject.send(gameData)
+                case .matchingResultConfirmButtonTapped(let gameData):
+                    navToMatchResultConfirmSubject.send(gameData)
                 case .refresh:
                     self.handleRefresh()
 
@@ -94,6 +103,8 @@ final class MatchingConfirmedViewModel: MatchingConfirmedViewModelProtocol {
 
         return Output(
             gameList: gameListSubject.eraseToAnyPublisher(),
+            navToMatchResultCreate: navToMatchResultCreateSubject.eraseToAnyPublisher(),
+            navToMatchResultConfirm: navToMatchResultConfirmSubject.eraseToAnyPublisher(),
             isLoading: isLoadingSubject.eraseToAnyPublisher(),
             isLoadingMore: isLoadingMoreSubject.eraseToAnyPublisher(),
             errorMessage: errorMessageSubject.eraseToAnyPublisher(),

--- a/SMASHING/Presentation/ReviewConfirm/ReviewConfirmView.swift
+++ b/SMASHING/Presentation/ReviewConfirm/ReviewConfirmView.swift
@@ -134,4 +134,4 @@ final class ReviewConfirmView: BaseUIView {
             $0.layer.borderWidth = 0
         }
     }
-} 
+}


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #112 

---

## 📎 Work Description 
- 매칭 관리 탭과 결과 작성 플로우 연결했습니다.
- 매칭 관리 탭 중 매칭 확정뷰 viewWillAppear 코드 추가
---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |


---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 매칭 결과 확인 페이지에서 결과 생성 및 확인 화면으로의 직접 이동 지원
  * 사용자 제출 소유권 및 게임 상태에 따른 버튼 상태 및 텍스트 동적 업데이트
  * 앱 재진입 시 매칭 정보 자동 갱신

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->