### PR TITLE
[feat]/#114 홈화면 및 랭킹화면 상대 프로필 연결

### DIFF
--- a/SMASHING/Global/Coordinators/Tab/HomeCoordinator.swift
+++ b/SMASHING/Global/Coordinators/Tab/HomeCoordinator.swift
@@ -48,8 +48,16 @@ final class HomeCoordinator: Coordinator {
             .store(in: &cancellables)
         
         output.navToRanking
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.showRanking()
+            }
+            .store(in: &cancellables)
+        
+        output.navToSelectedUserProfile
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] userId in
+                self?.showUserProfile(userId: userId)
             }
             .store(in: &cancellables)
     }
@@ -68,4 +76,25 @@ final class HomeCoordinator: Coordinator {
         rankingVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(rankingVC, animated: true)
     }
+    
+    private func showUserProfile(userId: String) {
+            let viewModel = UserProfileViewModel(userId: userId, sport: currentUserSport())
+            let userProfileVC = UserProfileViewController(viewModel: viewModel)
+            navigationController.pushViewController(userProfileVC, animated: true)
+        }
+        
+        private func currentUserSport() -> Sports {
+            guard let userId = KeychainService.get(key: Environment.userIdKey), !userId.isEmpty else {
+                return .badminton
+            }
+
+            let key = "\(Environment.sportsCodeKeyPrefix).\(userId)"
+            let rawValue = KeychainService.get(key: key)
+            guard let rawValue,
+                  let sport = Sports(rawValue: rawValue) else {
+                return .badminton
+            }
+
+            return sport
+        }
 }

--- a/SMASHING/Presentation/Home/HomeViewController.swift
+++ b/SMASHING/Presentation/Home/HomeViewController.swift
@@ -95,6 +95,7 @@ final class HomeViewController: BaseViewController {
             }
             .store(in: &cancellables)
     }
+    
     private func navigateToMatchResultConfirm(gameData: MatchingConfirmedGameDTO) {
         guard let submissionId = gameData.latestSubmissionId else { return }
         let viewModel = MatchResultConfirmViewModel(
@@ -139,10 +140,10 @@ extension HomeViewController: UICollectionViewDataSource {
             if recentMatching.isEmpty {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EmptyMatchingCell.reuseIdentifier, for: indexPath) as? EmptyMatchingCell else { return UICollectionViewCell() }
                 cell.onExploreButtonTapped = { [weak self] in
-//                           self?.input.send(.matchingSeeAllTapped) // “매칭 탐색” 이동 트리거
+                    //                           self?.input.send(.matchingSeeAllTapped) // “매칭 탐색” 이동 트리거
                     print("매칭 탐색하러가기")
-                       }
-                       return cell
+                }
+                return cell
             } else {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MatchingCell.reuseIdentifier, for: indexPath) as? MatchingCell else { return UICollectionViewCell() }
                 let matching = recentMatching[indexPath.item]
@@ -217,10 +218,20 @@ extension HomeViewController: UICollectionViewDataSource {
 }
 
 extension HomeViewController: UICollectionViewDelegate {
-    // 추후 프로필 이동 기능 구현 예정
-    //    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    //
-    //    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let sectionType = HomeViewLayout(rawValue: indexPath.section) else { return }
+        switch sectionType {
+        case .recommendedUser:
+            let user = recommendedUsers[indexPath.row]
+            input.send(.recommendedUserTapped(userId: user.userId))
+        case .ranking:
+            let ranker = rankings[indexPath.row]
+            input.send(.rankingUserTapped(userId: ranker.userId))
+        default:
+            break
+        }
+    }
 }
 
 // MARK: Header Button

--- a/SMASHING/Presentation/Home/HomeViewModel.swift
+++ b/SMASHING/Presentation/Home/HomeViewModel.swift
@@ -30,10 +30,10 @@ final class HomeViewModel: HomeViewModelProtocol {
         case matchingSeeAllTapped
         
         //추천 유저 섹션
-        case recommendedUserTapped
+        case recommendedUserTapped(userId: String)
         
         //랭킹 섹션
-        case rankingUserTapped
+        case rankingUserTapped(userId: String)
         case rankingSeeAllTapped
     }
     
@@ -49,7 +49,7 @@ final class HomeViewModel: HomeViewModelProtocol {
         let navToMatchResultCreate = PassthroughSubject<MatchingConfirmedGameDTO, Never>()
         let navToMatchResultConfirm = PassthroughSubject<MatchingConfirmedGameDTO, Never>()
         let navToMatchingManageTab = PassthroughSubject<Void, Never>()
-        let navToSelectedUserProfile = PassthroughSubject<Int, Never>()
+        let navToSelectedUserProfile = PassthroughSubject<String, Never>()
         let navToRanking = PassthroughSubject<Void, Never>()
     }
     private var cancellables = Set<AnyCancellable>()
@@ -82,10 +82,10 @@ final class HomeViewModel: HomeViewModelProtocol {
             output.navToMatchResultConfirm.send(gameData)
         case .matchingSeeAllTapped:
             output.navToMatchingManageTab.send()
-        case .recommendedUserTapped:
-            break
-        case .rankingUserTapped:
-            break
+        case .recommendedUserTapped(let userId):
+            output.navToSelectedUserProfile.send(userId)
+        case .rankingUserTapped(let userId):
+            output.navToSelectedUserProfile.send(userId)
         case .rankingSeeAllTapped:
             output.navToRanking.send()
 

--- a/SMASHING/Presentation/Ranking/RankingViewController.swift
+++ b/SMASHING/Presentation/Ranking/RankingViewController.swift
@@ -101,8 +101,13 @@ final class RankingViewController: BaseViewController {
                 self?.updateMyRanking()
             }
             .store(in: &cancellables)
-        //        output.navigateToUserProfile
-        //        output.navigateBack
+        
+        output.navigateToUserProfile
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] userId in
+                self?.showUserProfile(userId: userId)
+            }
+            .store(in: &cancellables)
     }
     
     private func setCollectionView() {
@@ -148,6 +153,27 @@ final class RankingViewController: BaseViewController {
         guard let myRanking = self.myRanking else { return }
         mainView.myRankingScore.configure(with: myRanking)
     }
+    
+    private func showUserProfile(userId: String) {
+            let viewModel = UserProfileViewModel(userId: userId, sport: currentUserSport())
+            let userProfileVC = UserProfileViewController(viewModel: viewModel)
+            navigationController?.pushViewController(userProfileVC, animated: true)
+        }
+        
+        private func currentUserSport() -> Sports {
+            guard let userId = KeychainService.get(key: Environment.userIdKey), !userId.isEmpty else {
+                return .badminton
+            }
+
+            let key = "\(Environment.sportsCodeKeyPrefix).\(userId)"
+            let rawValue = KeychainService.get(key: key)
+            guard let rawValue,
+                  let sport = Sports(rawValue: rawValue) else {
+                return .badminton
+            }
+
+            return sport
+        }
 }
 
 // MARK: - Extensions


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #114 

---

## 📎 Work Description 
- 홈이랑 랭킹뷰 상대 프로필 연동했습니다

---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |


---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 홈 화면의 추천 사용자 섹션에서 사용자를 선택하면 해당 사용자의 프로필 화면으로 이동합니다.
* 홈 화면의 랭킹 섹션에서 사용자를 선택하면 해당 사용자의 프로필 화면으로 이동합니다.
* 랭킹 화면에서도 사용자 프로필을 조회할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->