### PR TITLE
[feat]/#183 홈화면 주소 드롭다운 구현

### DIFF
--- a/SMASHING/Presentation/Home/Cell/HomeNavigationBarCell.swift
+++ b/SMASHING/Presentation/Home/Cell/HomeNavigationBarCell.swift
@@ -11,7 +11,7 @@ import Then
 import SnapKit
 
 final class HomeNavigationBarCell: BaseUICollectionViewCell, ReuseIdentifiable {
-    var onRegionButtonTapped: (() -> Void)?
+    var onRegionButtonTapped: ((_ regionFrame: CGRect) -> Void)?
     var onSportsAndTierTapped: (() -> Void)?
     var hasNewNotification: ((Bool) -> Void)?
     var onBellTapped: (() -> Void)?
@@ -126,7 +126,8 @@ final class HomeNavigationBarCell: BaseUICollectionViewCell, ReuseIdentifiable {
     
     @objc
     private func regionTapped() {
-        onRegionButtonTapped?()
+        let frame = regionStackView.convert(regionStackView.bounds, to: nil)
+        onRegionButtonTapped?(frame)
     }
     
     @objc

--- a/SMASHING/Presentation/Home/HomeDropDownView.swift
+++ b/SMASHING/Presentation/Home/HomeDropDownView.swift
@@ -110,7 +110,7 @@ final class HomeDropDownView: BaseUIView {
     
     override func setLayout() {
         regionStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(52)
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(13)
             $0.leading.equalToSuperview().inset(16)
         }
         

--- a/SMASHING/Presentation/Home/HomeViewController.swift
+++ b/SMASHING/Presentation/Home/HomeViewController.swift
@@ -24,6 +24,9 @@ final class HomeViewController: BaseViewController {
     private var isDropDownVisible = false
     private var dropDownBackgroundView: UIView?
     private var hasNewNotification: Bool = false
+    private var regionDropDownView: RegionDropDownView?
+    private var regionDropDownBackdrop: UIView?
+    private var isRegionDropDownShown = false
 
     private let dimView = UIView()
     
@@ -325,6 +328,86 @@ final class HomeViewController: BaseViewController {
         }
         return sport
     }
+    
+    private func showRegionDropDown(below sourceFrame: CGRect) {
+        guard !isRegionDropDownShown else { return }
+        isRegionDropDownShown = true
+
+        // 투명 backdrop - 바깥 탭 시 드롭다운 닫기
+        let backdrop = UIView()
+        regionDropDownBackdrop = backdrop
+        rootView.addSubview(backdrop)
+        backdrop.snp.makeConstraints { $0.edges.equalToSuperview() }
+        let tap = UITapGestureRecognizer(target: self, action: #selector(didTapRegionBackdrop))
+        backdrop.addGestureRecognizer(tap)
+        
+        let navIndexPath = IndexPath(item: 0, section: HomeViewLayout.navigationBar.rawValue)
+        guard let navAttr = homeView.layoutAttributesForItem(at: navIndexPath) else {
+            isRegionDropDownShown = false
+            return
+        }
+        let navCellFrameInRoot = homeView.convert(navAttr.frame, to: rootView)
+        let topY = navCellFrameInRoot.maxY + 4
+
+        let dd: RegionDropDownView
+        if let existing = regionDropDownView {
+            dd = existing
+            dd.configure(region: myRegion)
+            dd.snp.remakeConstraints {
+                $0.top.equalToSuperview().offset(topY)
+                $0.leading.equalToSuperview().offset(sourceFrame.minX)
+                $0.width.equalTo(123)
+            }
+        } else {
+            let newDD = RegionDropDownView()
+            regionDropDownView = newDD
+            dd = newDD
+
+            newDD.onCurrentRegionTapped = { [weak self] in
+                self?.hideRegionDropDown()
+            }
+            newDD.onChangeRegionTapped = { [weak self] in
+                self?.hideRegionDropDown()
+                self?.input.send(.regionTapped)
+            }
+            newDD.configure(region: myRegion)
+            rootView.addSubview(newDD)
+
+            newDD.snp.makeConstraints {
+                $0.top.equalToSuperview().offset(topY)
+                $0.leading.equalToSuperview().offset(sourceFrame.minX)
+                $0.width.equalTo(123)
+            }
+        }
+
+        rootView.bringSubviewToFront(dd)
+
+        dd.alpha = 0
+        dd.transform = CGAffineTransform(translationX: 0, y: -8)
+
+        UIView.animate(withDuration: 0.22, delay: 0, options: [.curveEaseOut]) {
+            dd.alpha = 1
+            dd.transform = .identity
+        }
+    }
+
+    private func hideRegionDropDown() {
+        guard isRegionDropDownShown else { return }
+        isRegionDropDownShown = false
+
+        UIView.animate(withDuration: 0.18, delay: 0, options: [.curveEaseIn]) {
+            self.regionDropDownView?.alpha = 0
+            self.regionDropDownView?.transform = CGAffineTransform(translationX: 0, y: -8)
+        } completion: { _ in
+            self.regionDropDownView?.transform = .identity
+            self.regionDropDownBackdrop?.removeFromSuperview()
+            self.regionDropDownBackdrop = nil
+        }
+    }
+
+    @objc private func didTapRegionBackdrop() {
+        hideRegionDropDown()
+    }
 
     private func showRegionSelection() {
         let addressVC = AddressSearchViewController(mode: .changeRegion)
@@ -378,8 +461,10 @@ extension HomeViewController: UICollectionViewDataSource {
             let tierCode = latestMyProfile?.activeProfile.tierCode ?? ""
             
             cell.configure(region: myRegion, sportCode: sportCode, tierCode: tierCode)
-            cell.onRegionButtonTapped = { [weak self] in
-                self?.input.send(.regionTapped)
+            cell.onRegionButtonTapped = { [weak self] regionFrame in
+                guard let self else { return }
+                let frameInRoot = self.rootView.convert(regionFrame, from: nil)
+                self.showRegionDropDown(below: frameInRoot)
             }
             cell.onSportsAndTierTapped = { [weak self] in
                 self?.toggleDropDown()

--- a/SMASHING/Presentation/Home/RegionDropDownView.swift
+++ b/SMASHING/Presentation/Home/RegionDropDownView.swift
@@ -1,0 +1,84 @@
+//
+//  RegionDropDownView.swift
+//  SMASHING
+//
+//  Created by 홍준범 on 3/21/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RegionDropDownView: BaseUIView {
+
+    // MARK: - Callbacks
+
+    var onCurrentRegionTapped: (() -> Void)?
+    var onChangeRegionTapped: (() -> Void)?
+
+    // MARK: - UI Components
+
+    private let currentRegionButton = UIButton(type: .system).then {
+        $0.setTitleColor(.Text.primary, for: .normal)
+        $0.titleLabel?.font = .pretendard(.textMdM)
+    }
+
+    private let dividerView = UIView().then {
+        $0.backgroundColor = .Border.secondary
+    }
+
+    private let changeRegionButton = UIButton(type: .system).then {
+        $0.setTitle("내 지역 변경", for: .normal)
+        $0.setTitleColor(.Text.primary, for: .normal)
+        $0.titleLabel?.font = .pretendard(.textMdM)
+    }
+
+    // MARK: - Setup
+
+    override func setUI() {
+        backgroundColor = .Background.surface
+        layer.cornerRadius = 8
+        clipsToBounds = true
+
+        addSubviews(currentRegionButton, dividerView, changeRegionButton)
+
+        currentRegionButton.addTarget(self, action: #selector(currentRegionButtonDidTap), for: .touchUpInside)
+        changeRegionButton.addTarget(self, action: #selector(changeRegionButtonDidTap), for: .touchUpInside)
+    }
+
+    override func setLayout() {
+        currentRegionButton.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+
+        dividerView.snp.makeConstraints {
+            $0.top.equalTo(currentRegionButton.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(12)
+            $0.height.equalTo(1)
+        }
+
+        changeRegionButton.snp.makeConstraints {
+            $0.top.equalTo(dividerView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+    }
+
+    // MARK: - Configure
+
+    func configure(region: String) {
+        currentRegionButton.setTitle(region, for: .normal)
+    }
+
+    // MARK: - Actions
+
+    @objc private func currentRegionButtonDidTap() {
+        onCurrentRegionTapped?()
+    }
+
+    @objc private func changeRegionButtonDidTap() {
+        onChangeRegionTapped?()
+    }
+}


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #183 

---

## 📎 Work Description 
- 홈화면 주소 변경 드롭다운 구현
---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/ab22cf7e-b5b0-4d85-8aa8-18033dcd6bc3" width="250"> | <img src="https://github.com/user-attachments/assets/35c98bf0-2ac9-4cd8-ab08-33a54a3ff8da" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지역 드롭다운 메뉴 추가 — 현재 지역 확인 및 변경 옵션 제공.
  * 지역 버튼 탭 시 버튼 위치를 기준으로 드롭다운이 정확히 화면에 표시됩니다.
  * 전체화면 백드롭으로 외부 터치 시 메뉴가 닫히며 등장/퇴장 애니메이션이 적용됩니다.

* **버그 수정**
  * 드롭다운 및 관련 UI의 세이프 영역과 위치 정렬을 개선하여 표시 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->