### PR TITLE
[feat]/#187 매칭 결과 작성 및 확인 뷰에서 점수 입력 부분 제거

### DIFF
--- a/SMASHING/Networks/API/Game/GameAPI.swift
+++ b/SMASHING/Networks/API/Game/GameAPI.swift
@@ -9,8 +9,8 @@ import Alamofire
 import Moya
 
 enum GameAPI {
-    case submissionResult(gameId: String, request: GameFirstSubmissionRequestDTO)
-    case resubmission(gameId: String, request: GameResubmissionRequestDTO)
+    case submissionResult(gameId: String, request: GameSubmissionRequestDTO)
+    case resubmission(gameId: String, request: GameSubmissionRequestDTO)
     case submissionConfirm(gameId: String, submissionId: String, request: GameConfirmRequestDTO)
     case rejectSubmission(gameId: String, submissionId: String, request: GameRejectRequestDTO)
     case deleteMatchBeforeConfirm //진재

--- a/SMASHING/Networks/DTO/Game/GameSubmissionRequestDTO.swift
+++ b/SMASHING/Networks/DTO/Game/GameSubmissionRequestDTO.swift
@@ -7,19 +7,10 @@
 
 import Foundation
 
-struct GameFirstSubmissionRequestDTO: Encodable {
-    let winnerUserId: String
-    let loserUserId: String
-    let scoreWinner: Int
-    let scoreLoser: Int
-    let review: ReviewRequestDTO
-}
-
-struct GameResubmissionRequestDTO: Encodable {
-    let winnerUserId: String
-    let loserUserId: String
-    let scoreWinner: Int
-    let scoreLoser: Int
+struct GameSubmissionRequestDTO: Encodable {
+    let winnerProfileId: String
+    let loserProfileId: String
+    let review: ReviewRequestDTO?
 }
 
 struct ReviewRequestDTO: Encodable {

--- a/SMASHING/Networks/Service/Game/GameService.swift
+++ b/SMASHING/Networks/Service/Game/GameService.swift
@@ -9,15 +9,15 @@ import Foundation
 import Combine
 
 protocol GameServiceProtocol {
-    func submitResult(gameId: String, request: GameFirstSubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError>
-    func resubmitResult(gameId: String, request: GameResubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError>
+    func submitResult(gameId: String, request: GameSubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError>
+    func resubmitResult(gameId: String, request: GameSubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError>
     func getSubmissionDetail(gameId: String, submissionId: String) -> AnyPublisher<GameSubmissionDetailDTO, NetworkError>
     func rejectSubmission(gameId: String, submissionId: String, reason: String?) -> AnyPublisher<Void, NetworkError>
     func confirmSubmission(gameId: String, submissionId: String, review: ReviewRequestDTO) -> AnyPublisher<GameConfirmResponseDTO, NetworkError>
 }
 
 final class GameService: GameServiceProtocol {
-    func submitResult(gameId: String, request: GameFirstSubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError> {
+    func submitResult(gameId: String, request: GameSubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError> {
         return NetworkProvider<GameAPI>
             .requestPublisher(.submissionResult(gameId: gameId, request: request), type: GameSubmissionResponseDTO.self)
             .map { response in
@@ -26,7 +26,7 @@ final class GameService: GameServiceProtocol {
             .eraseToAnyPublisher()
     }
     
-    func resubmitResult(gameId: String, request: GameResubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError> {
+    func resubmitResult(gameId: String, request: GameSubmissionRequestDTO) -> AnyPublisher<GameSubmissionResponseDTO, NetworkError> {
         return NetworkProvider<GameAPI>
             .requestPublisher(.resubmission(gameId: gameId, request: request), type: GameSubmissionResponseDTO.self)
             .map { response in

--- a/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmView.swift
+++ b/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmView.swift
@@ -47,50 +47,6 @@ final class MatchResultConfirmView: BaseUIView {
         $0.textAlignment = .center
     }
     
-    // MARK: - 스코어 영역
-    
-    private let scoreLabel = UILabel().then {
-        $0.text = "스코어"
-        $0.setPretendard(.textMdM)
-        $0.textColor = .Text.primary
-    }
-    
-    private let scoreRequiredStar = UILabel().then {
-        $0.text = "*"
-        $0.setPretendard(.textMdM)
-        $0.textColor = .Text.red
-    }
-    
-    private let myScoreView = UIView().then {
-        $0.backgroundColor = .Background.surface
-        $0.layer.cornerRadius = 8
-    }
-    
-    private let myScoreLabel = UILabel().then {
-        $0.text = "0"
-        $0.setPretendard(.textMdM)
-        $0.textColor = .Text.primary
-        $0.textAlignment = .center
-    }
-    
-    private let scoreSemicolonLabel = UILabel().then {
-        $0.text = ":"
-        $0.setPretendard(.textSmM)
-        $0.textColor = .Text.primary
-    }
-    
-    private let opponentScoreView = UIView().then {
-        $0.backgroundColor = .Background.surface
-        $0.layer.cornerRadius = 8
-    }
-    
-    private let opponentScoreLabel = UILabel().then {
-        $0.text = "0"
-        $0.setPretendard(.textMdM)
-        $0.textColor = .Text.primary
-        $0.textAlignment = .center
-    }
-    
     // MARK: - 하단 버튼 영역
     
     private let confirmQuestionLabel = UILabel().then {
@@ -125,8 +81,6 @@ final class MatchResultConfirmView: BaseUIView {
     override func setUI() {
         backgroundColor = .clear
         winnerValueView.addSubview(winnerValueLabel)
-        myScoreView.addSubview(myScoreLabel)
-        opponentScoreView.addSubview(opponentScoreLabel)
         buttonStackView.addArrangedSubviews(rejectButton, confirmButton)
         
         addSubviews(navigationBar,
@@ -135,11 +89,6 @@ final class MatchResultConfirmView: BaseUIView {
                     winnerLabel,
                     winnerRequiredStar,
                     winnerValueView,
-                    scoreLabel,
-                    scoreRequiredStar,
-                    myScoreView,
-                    scoreSemicolonLabel,
-                    opponentScoreView,
                     confirmQuestionLabel,
                     buttonStackView)
     }
@@ -183,43 +132,6 @@ final class MatchResultConfirmView: BaseUIView {
             $0.center.equalToSuperview()
         }
         
-        // 스코어 영역
-        scoreLabel.snp.makeConstraints {
-            $0.top.equalTo(winnerLabel.snp.bottom).offset(41)
-            $0.leading.equalToSuperview().inset(16)
-        }
-        
-        scoreRequiredStar.snp.makeConstraints {
-            $0.top.equalTo(scoreLabel)
-            $0.leading.equalTo(scoreLabel.snp.trailing)
-        }
-        
-        myScoreView.snp.makeConstraints {
-            $0.centerY.equalTo(scoreLabel)
-            $0.leading.equalTo(winnerValueView.snp.leading)
-            $0.width.equalTo(56)
-            $0.height.equalTo(45)
-        }
-        
-        myScoreLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-        
-        scoreSemicolonLabel.snp.makeConstraints {
-            $0.centerY.equalTo(scoreLabel)
-            $0.leading.equalTo(myScoreView.snp.trailing).offset(12)
-        }
-        
-        opponentScoreView.snp.makeConstraints {
-            $0.centerY.equalTo(scoreLabel)
-            $0.trailing.equalTo(winnerValueView.snp.trailing)
-            $0.width.height.equalTo(myScoreView)
-        }
-        
-        opponentScoreLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-        
         // 하단 버튼 영역
         confirmQuestionLabel.snp.makeConstraints {
             $0.bottom.equalTo(buttonStackView.snp.top).offset(-16)
@@ -242,8 +154,6 @@ final class MatchResultConfirmView: BaseUIView {
     func configure(
         myNickname: String,
         opponentNickname: String,
-        myScore: Int,
-        opponentScore: Int,
         winnerNickname: String
     ) {
         matchResultCard.configure(
@@ -252,13 +162,10 @@ final class MatchResultConfirmView: BaseUIView {
             rivalName: opponentNickname,
             rivalImage: UIImage(systemName: "circle.fill")
         )
-        matchResultCard.updateScore(myScore: "\(myScore)", rivalScore: "\(opponentScore)")
         
         let isMyWin = (winnerNickname == myNickname)
         matchResultCard.updateWinnerCrown(isMyWin: isMyWin)
         
         winnerValueLabel.text = winnerNickname
-        myScoreLabel.text = "\(myScore)"
-        opponentScoreLabel.text = "\(opponentScore)"
     }
 }

--- a/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmViewController.swift
+++ b/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmViewController.swift
@@ -55,8 +55,6 @@ final class MatchResultConfirmViewController: BaseViewController {
                 self?.mainView.configure(
                     myNickname: data.myNickname,
                     opponentNickname: data.opponentNickname,
-                    myScore: data.myScore,
-                    opponentScore: data.opponentScore,
                     winnerNickname: data.winnerNickname
                 )
             }

--- a/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmViewModel.swift
+++ b/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmViewModel.swift
@@ -112,18 +112,14 @@ final class MatchResultConfirmViewModel: MatchResultConfirmViewModelProtocol {
     }
     
     private func mapToConfirmData(dto: GameSubmissionDetailDTO) -> MatchResultConfirmData {
-        let isMyWin = dto.winner.userId == myUserId
+//        let isMyWin = dto.winner.userId == myUserId
         
         return MatchResultConfirmData(
             myNickname: myNickname,
             opponentNickname: gameData.opponent.nickname,
-            myScore: isMyWin ? dto.winner.score : dto.loser.score,
-            opponentScore: isMyWin ? dto.loser.score : dto.winner.score,
             winnerNickname: dto.winner.nickname,
-            winnerUserId: dto.winner.userId,
-            loserUserId: dto.loser.userId,
-            scoreWinner: dto.winner.score,
-            scoreLoser: dto.loser.score,
+            winnerProfileId: dto.winner.userId,
+            loserProfileId: dto.loser.userId,
             submissionId: submissionId,
             isFirstSubmission: dto.attemptNo == 1
         )
@@ -165,13 +161,9 @@ final class MatchResultConfirmViewModel: MatchResultConfirmViewModelProtocol {
 struct MatchResultConfirmData {
     let myNickname: String
     let opponentNickname: String
-    let myScore: Int
-    let opponentScore: Int
     let winnerNickname: String
-    let winnerUserId: String
-    let loserUserId: String
-    let scoreWinner: Int
-    let scoreLoser: Int
+    let winnerProfileId: String
+    let loserProfileId: String
     let submissionId: String
     let isFirstSubmission: Bool  // attemptNo == 1 여부
 }

--- a/SMASHING/Presentation/MatchResultConfirm/RejectReasonBottomSheetViewController.swift
+++ b/SMASHING/Presentation/MatchResultConfirm/RejectReasonBottomSheetViewController.swift
@@ -13,19 +13,13 @@ import Then
 // MARK: - RejectReason
 
 enum RejectReason: String, CaseIterable {
-    case wrongScore = "SCORE_MISMATCH"
     case wrongWinner = "WIN_LOSE_REVERSED"
-    case wrongBoth = "SCORE_AND_WIN_LOSE_MISMATCH"
     case notPlayed = "GAME_NOT_PLAYED_YET"
     
     var displayText: String {
         switch self {
-        case .wrongScore:
-            return "스코어가 잘못됐어요"
         case .wrongWinner:
             return "승자가 잘못됐어요"
-        case .wrongBoth:
-            return "스코어와 승자 모두 잘못됐어요"
         case .notPlayed:
             return "아직 진행하지 않은 경기예요"
         }

--- a/SMASHING/Presentation/MatchResultCreate/MatchResultCreateView.swift
+++ b/SMASHING/Presentation/MatchResultCreate/MatchResultCreateView.swift
@@ -17,7 +17,6 @@ final class MatchResultCreateView: BaseUIView {
     private var selectedWinner: String?
     
     var onBackTapped: (() -> Void)?
-    var onScoreChanged: ((Int?, Int?, Bool, Bool) -> Void)?
     
     lazy var navigationBar = CustomNavigationBar(title: "결과 작성",
                                                  leftAction: { [weak self] in
@@ -69,28 +68,6 @@ final class MatchResultCreateView: BaseUIView {
         $0.setTitleColor(.Text.primary, for: .normal)
     }
     
-    private let scoreLabel = UILabel().then {
-        $0.text = "스코어"
-        $0.setPretendard(.textMdM)
-        $0.textColor = .Text.primary
-    }
-    
-    private let scoreRequiredStar = UILabel().then {
-        $0.text = "*"
-        $0.setPretendard(.textMdM)
-        $0.textColor = .Text.red
-    }
-    
-    private lazy var myScoreTextField = ScoreTextField()
-    
-    private let semiColonLabel = UILabel().then {
-        $0.text = ":"
-        $0.font = .pretendard(.textSmM)
-        $0.textColor = .Text.primary
-    }
-    
-    private lazy var rivalScoreTextField = ScoreTextField()
-    
     let nextButton = CTAButton(label: "다음")
     
     override func setUI() {
@@ -101,25 +78,10 @@ final class MatchResultCreateView: BaseUIView {
                     subTitleLabel,
                     matchResultCard,
                     winnerLabel,
-                    scoreLabel,
                     winnerRequiredStar,
                     winnerDropDown,
-                    scoreRequiredStar,
                     nextButton,
-                    myScoreTextField,
-                    semiColonLabel,
-                    rivalScoreTextField,
                     dropDownOptionsView)
-        
-        myScoreTextField.onDone = { [weak self] in
-            self?.updateScoreToMatchResultCard()
-            self?.notifyScoreChanged()
-        }
-        
-        rivalScoreTextField.onDone = { [weak self] in
-            self?.updateScoreToMatchResultCard()
-            self?.notifyScoreChanged()
-        }
         
         nextButton.isEnabled = false
     }
@@ -179,34 +141,6 @@ final class MatchResultCreateView: BaseUIView {
             $0.height.equalTo(48)
         }
         
-        scoreLabel.snp.makeConstraints {
-            $0.top.equalTo(winnerLabel.snp.bottom).offset(41)
-            $0.leading.equalToSuperview().inset(16)
-        }
-        
-        scoreRequiredStar.snp.makeConstraints {
-            $0.top.equalTo(scoreLabel)
-            $0.leading.equalTo(scoreLabel.snp.trailing)
-        }
-        
-        myScoreTextField.snp.makeConstraints {
-            $0.centerY.equalTo(scoreLabel)
-            $0.leading.equalTo(winnerDropDown.snp.leading)
-            $0.width.equalTo(56)
-            $0.height.equalTo(45)
-        }
-        
-        semiColonLabel.snp.makeConstraints {
-            $0.centerY.equalTo(scoreLabel)
-            $0.leading.equalTo(myScoreTextField.snp.trailing).offset(12)
-        }
-        
-        rivalScoreTextField.snp.makeConstraints {
-            $0.centerY.equalTo(scoreLabel)
-            $0.trailing.equalTo(winnerDropDown.snp.trailing)
-            $0.width.height.equalTo(myScoreTextField)
-        }
-        
         nextButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(47)
             $0.leading.trailing.equalToSuperview().inset(16)
@@ -236,46 +170,10 @@ final class MatchResultCreateView: BaseUIView {
             toggleDropDown()
         }
         updateWinnerUI()
-        notifyScoreChanged()
-    }
-    
-    private func notifyScoreChanged() {
-        let myText = myScoreTextField.text ?? ""
-        let opponentText = rivalScoreTextField.text ?? ""
-        let hasMyScore = !myText.isEmpty
-        let hasOpponentScore = !opponentText.isEmpty
-        
-        let myScore = hasMyScore ? Int(myText) : nil
-        let opponentScore = hasOpponentScore ? Int(opponentText) : nil
-        onScoreChanged?(myScore, opponentScore, hasMyScore, hasOpponentScore)
-        
-//        let myScore = getMyScore()
-//        let opponentScore = getOpponentScore()
-//        onScoreChanged?(myScore, opponentScore)
-    }
-    
-    private func updateScoreToMatchResultCard() {
-        let myScoreText: String
-        if let text = myScoreTextField.text, !text.isEmpty {
-            myScoreText = text
-        } else {
-            myScoreText = "0"
-        }
-        
-        let rivalScoreText: String
-        if let text = rivalScoreTextField.text, !text.isEmpty {
-            rivalScoreText = text
-        } else {
-            rivalScoreText = "0"
-        }
-        
-        matchResultCard.updateScore(myScore: myScoreText, rivalScore: rivalScoreText)
     }
     
     private func updateWinnerUI() {
-        guard let selectedWinner = selectedWinner else {
-            return
-        }
+        guard let selectedWinner else { return }
         
         let isMyWin = (selectedWinner == myOptionButton.titleLabel?.text)
         matchResultCard.updateWinnerCrown(isMyWin: isMyWin)
@@ -286,13 +184,6 @@ final class MatchResultCreateView: BaseUIView {
         myOptionButton.setTitle(myNickname, for: .normal)
         rivalOptionButton.setTitle(opponentNickname, for: .normal)
         matchResultCard.configure(myName: myNickname, myImage: UIImage(systemName: "circle.fill"), rivalName: opponentNickname, rivalImage: UIImage(systemName: "circle.fill"))
-    }
-    
-    func applyPrefillData(myScore: Int, opponentScore: Int) {
-        myScoreTextField.text = String(myScore)
-        rivalScoreTextField.text = String(opponentScore)
-        updateScoreToMatchResultCard()
-        notifyScoreChanged()
     }
     
     func getSelectedWinner() -> String? {

--- a/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewController.swift
+++ b/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewController.swift
@@ -53,10 +53,6 @@ final class MatchResultCreateViewController: BaseViewController {
         mainView.nextButton.addTarget(self, action: #selector(didTapNextButton), for: .touchUpInside)
         mainView.myOptionButton.addTarget(self, action: #selector(didTapMyOptionButton), for: .touchUpInside)
         mainView.rivalOptionButton.addTarget(self, action: #selector(didTapRivalOptionButton), for: .touchUpInside)
-        
-        mainView.onScoreChanged = { [weak self] myScore, opponentScore, hasMyScore, hasOpponentScore in
-            self?.input.send(.scoreChanged(myScore: myScore, opponentScore: opponentScore, hasMyScore: hasMyScore, hasOpponentScore: hasOpponentScore))
-        }
     }
     
     private func bind() {
@@ -88,13 +84,6 @@ final class MatchResultCreateViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] winner in
                 self?.mainView.updateSelectedWinner(winner)
-            }
-            .store(in: &cancellables)
-        
-        output.prefillData
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] prefill in
-                self?.mainView.applyPrefillData(myScore: prefill.myScore, opponentScore: prefill.opponentScore)
             }
             .store(in: &cancellables)
         
@@ -168,8 +157,6 @@ final class MatchResultCreateViewController: BaseViewController {
 }
 
 struct MatchResultData {
-    let winnerUserId: String
-    let loserUserId: String
-    let scoreWinner: Int
-    let scoreLoser: Int
+    let winnerProfileId: String
+    let loserProfileId: String
 }

--- a/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewModel.swift
+++ b/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewModel.swift
@@ -12,8 +12,6 @@ import Combine
 
 struct MatchResultPrefillData {
     let winnerNickname: String
-    let myScore: Int
-    let opponentScore: Int
 }
 
 protocol MatchResultCreateViewModelProtocol: InputOutputProtocol {
@@ -27,7 +25,6 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
         case winnerDropDownTapped
         case myOptionSelected
         case rivalOptionSelected
-        case scoreChanged(myScore: Int?, opponentScore: Int?, hasMyScore: Bool, hasOpponentScore: Bool)
         case nextButtonTapped
         case submitResubmissionConfirmed(MatchResultData)
     }
@@ -59,10 +56,6 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     private let myNickname: String
     
     private var selectedWinner: String?
-    private var myScore: Int = 0
-    private var opponentScore: Int = 0
-    private var hasMyScore: Bool = false
-    private var hasOpponentScore: Bool = false
     
     private var cancellables = Set<AnyCancellable>()
     let output = Output()
@@ -99,12 +92,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
             
         case .rivalOptionSelected:
             selectWinner(gameData.opponent.nickname)
-        case .scoreChanged(let myScore, let opponentScore, let hasMyScore, let hasOpponentScore):
-            self.myScore = myScore ?? 0
-            self.opponentScore = opponentScore ?? 0
-            self.hasMyScore = hasMyScore
-            self.hasOpponentScore = hasOpponentScore
-            validateWinnerAndScore()
+
         case .nextButtonTapped:
             handleNextButtonTapped()
         case .submitResubmissionConfirmed(let matchResultData):
@@ -117,7 +105,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
         output.myNickname.send(myNickname)
         output.opponentNickname.send(gameData.opponent.nickname)
         
-        let buttonTitle = gameData.resultStatus.isFirstSubmission ? "다음" : "완료" //여기 해야함
+        let buttonTitle = gameData.resultStatus.isFirstSubmission ? "다음" : "완료"
         output.nextButtonTitle.send(buttonTitle)
         output.isNextButtonEnabled.send(false)
         
@@ -129,24 +117,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     private func selectWinner(_ winner: String) {
         selectedWinner = winner
         output.selectedWinner.send(winner)
-        validateWinnerAndScore()
-    }
-    
-    private func validateWinnerAndScore() {
-        guard let selectedWinner = selectedWinner else {
-            output.isNextButtonEnabled.send(false)
-            return
-        }
-        
-        guard hasMyScore, hasOpponentScore else {
-            output.isNextButtonEnabled.send(false)
-            return 
-        }
-        
-        let isMyWin = (selectedWinner == myNickname)
-        let isScoreValid = isMyWin ? (myScore > opponentScore) : (opponentScore > myScore)
-        
-        output.isNextButtonEnabled.send(isScoreValid)
+        output.isNextButtonEnabled.send(true)
     }
     
     private func handleNextButtonTapped() {
@@ -160,24 +131,16 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     }
     
     private func createMatchResultData() -> MatchResultData {
-        guard let selectedWinner = selectedWinner else {
-            return MatchResultData(winnerUserId: "", loserUserId: "", scoreWinner: 0, scoreLoser: 0)
+        guard let selectedWinner else {
+            return MatchResultData(winnerProfileId: "", loserProfileId: "")
         }
         
         let isMyWin = (selectedWinner == myNickname)
         
-        let winnerUserId = isMyWin ? myUserId : gameData.opponent.userID
-        let loserUserId = isMyWin ? gameData.opponent.userID : myUserId
+        let winnerProfileId = isMyWin ? myUserId : gameData.opponent.userID
+        let loserProfileId = isMyWin ? gameData.opponent.userID : myUserId
         
-        let scoreWinner = isMyWin ? myScore : opponentScore
-        let scoreLoser = isMyWin ? opponentScore : myScore
-        
-        return MatchResultData(
-            winnerUserId: winnerUserId,
-            loserUserId: loserUserId,
-            scoreWinner: scoreWinner,
-            scoreLoser: scoreLoser
-        )
+        return MatchResultData(winnerProfileId: winnerProfileId, loserProfileId: loserProfileId)
     }
     
     private var shouldPrefillResubmission: Bool {
@@ -198,15 +161,12 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
                 }
             } receiveValue: { [weak self] dto in
                 guard let self else { return }
-                let matchResultData = MatchResultData(winnerUserId: dto.winner.userId, loserUserId: dto.loser.userId, scoreWinner: dto.winner.score, scoreLoser: dto.loser.score)
-                let isMyWin = matchResultData.winnerUserId == self.myUserId
-                let prefill = MatchResultPrefillData(winnerNickname: isMyWin ? self.myNickname : self.gameData.opponent.nickname, myScore: isMyWin ? matchResultData.scoreWinner : matchResultData.scoreLoser, opponentScore: isMyWin ? matchResultData.scoreLoser : matchResultData.scoreWinner)
-                self.selectedWinner = prefill.winnerNickname
-                self.myScore = prefill.myScore
-                self.opponentScore = prefill.opponentScore
-                self.output.prefillData.send(prefill)
-                self.output.selectedWinner.send(prefill.winnerNickname)
-                self.validateWinnerAndScore()
+                let isMyWin = dto.winner.userId == self.myUserId
+                let winnerNickname = isMyWin ? self.myNickname : self.gameData.opponent.nickname
+                self.selectedWinner = winnerNickname
+                self.output.prefillData.send(MatchResultPrefillData(winnerNickname: winnerNickname))
+                self.output.selectedWinner.send(winnerNickname)
+                self.output.isNextButtonEnabled.send(true)
             }
             .store(in: &cancellables)
     }
@@ -214,11 +174,10 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     private func submitResubmission(_ matchResultData: MatchResultData) {
         output.isLoading.send(true)
         
-        let request = GameResubmissionRequestDTO(
-            winnerUserId: matchResultData.winnerUserId,
-            loserUserId: matchResultData.loserUserId,
-            scoreWinner: matchResultData.scoreWinner,
-            scoreLoser: matchResultData.scoreLoser
+        let request = GameSubmissionRequestDTO(
+            winnerProfileId: matchResultData.winnerProfileId,
+            loserProfileId: matchResultData.loserProfileId,
+            review: nil
         )
         
         gameService.resubmitResult(gameId: gameData.gameID, request: request)

--- a/SMASHING/Presentation/ReviewCreate/ViewModel/ReviewCreateViewModel.swift
+++ b/SMASHING/Presentation/ReviewCreate/ViewModel/ReviewCreateViewModel.swift
@@ -164,11 +164,9 @@ final class ReviewCreateViewModel: ReviewCreateViewModelProtocol {
                 tags: selectedTags.isEmpty ? nil : selectedTags.map { $0.rawValue }
             )
 
-            let requestDTO = GameFirstSubmissionRequestDTO(
-                winnerUserId: matchResultData.winnerUserId,
-                loserUserId: matchResultData.loserUserId,
-                scoreWinner: matchResultData.scoreWinner,
-                scoreLoser: matchResultData.scoreLoser,
+            let requestDTO = GameSubmissionRequestDTO(
+                winnerProfileId: matchResultData.winnerProfileId,
+                loserProfileId: matchResultData.loserProfileId,
                 review: reviewRequestDTO
             )
 


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #187

---

## 📎 Work Description 
- 매칭 결과 작성 및 확인하기 뷰에서 점수 입력 부분제거
- 점수 입력 부분 제거에 따른 API 및 DTO 구조 수정

---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

응답 받아줄 사람이 없어서,, 사진을 못찍음 ㅠ

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 매치 결과 생성 시 스코어 입력 필드가 제거되었습니다.
  * 매치 결과 확인 화면에서 스코어 표시가 제거되었습니다.
  * 거절 사유 목록에서 스코어 관련 옵션이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->