### PR TITLE
[feat]/#196 매칭 결과 제출 오류 수정

### DIFF
--- a/SMASHING/Global/Environment.swift
+++ b/SMASHING/Global/Environment.swift
@@ -19,4 +19,5 @@ enum Environment {
     static let nicknameKey: String = "nicknameKey"
     static let sportsCodeKeyPrefix: String = "sportsCode"
     static let regionKey: String = "regionKey"
+    static let activeProfileKey: String = "activeProfileId"
 }

--- a/SMASHING/Presentation/Home/HomeViewController.swift
+++ b/SMASHING/Presentation/Home/HomeViewController.swift
@@ -53,6 +53,10 @@ final class HomeViewController: BaseViewController {
         return KeychainService.get(key: Environment.userIdKey) ?? ""
     }
     
+    private var myProfileId: String {
+        return latestMyProfile?.activeProfile.profileId ?? ""
+    }
+    
     private var myRegion: String {
         return UserDefaults.standard.string(forKey: UserDefaultKey.region) ?? ""
     }
@@ -260,7 +264,7 @@ final class HomeViewController: BaseViewController {
         let viewModel = MatchResultConfirmViewModel(
             gameData: gameData,
             submissionId: submissionId,
-            myUserId: myUserId
+            myProfileId: myProfileId
         )
         let vc = MatchResultConfirmViewController(viewModel: viewModel)
         NavigationManager.shared.push(vc, hidesBottomBar: true)
@@ -269,7 +273,7 @@ final class HomeViewController: BaseViewController {
     // MARK: - Navigation Methods
     
     private func showMatchResultCreate(with gameData: MatchingConfirmedGameDTO) {
-        let vm = MatchResultCreateViewModel(gameData: gameData, myUserId: myUserId, myNickname: myNickname)
+        let vm = MatchResultCreateViewModel(gameData: gameData, myProfileId: myProfileId, myNickname: myNickname)
         let vc = MatchResultCreateViewController(viewModel: vm)
         NavigationManager.shared.push(vc, hidesBottomBar: true)
     }
@@ -494,10 +498,10 @@ extension HomeViewController: UICollectionViewDataSource {
             } else {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MatchingCell.reuseIdentifier, for: indexPath) as? MatchingCell else { return UICollectionViewCell() }
                 let matching = recentMatching[indexPath.item]
-                cell.configure(with: matching, myNickname: myNickname, myUserId: myUserId)
+                cell.configure(with: matching, myNickname: myNickname, myUserId: myProfileId)
                 cell.onWriteResultButtonTapped = { [weak self] in
                     guard let self else { return }
-                    let isMySubmission = matching.latestSubmitterId == self.myUserId
+                    let isMySubmission = matching.latestSubmitterId == self.myProfileId
                     let canConfirm = matching.resultStatus.canConfirm(isMySubmission: isMySubmission)
                     if canConfirm {
                         // 상대방이 제출한 결과 확인 플로우

--- a/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmViewModel.swift
+++ b/SMASHING/Presentation/MatchResultConfirm/MatchResultConfirmViewModel.swift
@@ -38,7 +38,7 @@ final class MatchResultConfirmViewModel: MatchResultConfirmViewModelProtocol {
     private let gameData: MatchingConfirmedGameDTO
     private let submissionId: String
     
-    private let myUserId: String
+    private let myProfileId: String
     private var myNickname: String {
         return KeychainService.get(key: Environment.nicknameKey) ?? ""
     }
@@ -52,12 +52,12 @@ final class MatchResultConfirmViewModel: MatchResultConfirmViewModelProtocol {
     init(
         gameData: MatchingConfirmedGameDTO,
         submissionId: String,
-        myUserId: String,
+        myProfileId: String,
         gameService: GameServiceProtocol = GameService()
     ) {
         self.gameData = gameData
         self.submissionId = submissionId
-        self.myUserId = myUserId
+        self.myProfileId = myProfileId
         self.gameService = gameService
     }
     

--- a/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewController.swift
+++ b/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewController.swift
@@ -96,8 +96,8 @@ final class MatchResultCreateViewController: BaseViewController {
         
         output.navToReviewCreate
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] gameData, matchResultData, myUserId in
-                self?.navigateToReviewCreate(gameData: gameData, matchResultData: matchResultData, myUserId: myUserId)
+            .sink { [weak self] gameData, matchResultData in
+                self?.navigateToReviewCreate(gameData: gameData, matchResultData: matchResultData)
             }
             .store(in: &cancellables)
         
@@ -136,10 +136,10 @@ final class MatchResultCreateViewController: BaseViewController {
         input.send(.nextButtonTapped)
     }
     
-    private func navigateToReviewCreate(gameData: MatchingConfirmedGameDTO, matchResultData: MatchResultData, myUserId: String) {
-        let flowType = ReviewFlowType.submission(gameData: gameData, matchResultData: matchResultData, myUserId: myUserId)
+    private func navigateToReviewCreate(gameData: MatchingConfirmedGameDTO, matchResultData: MatchResultData) {
+        let flowType = ReviewFlowType.submission(gameData: gameData, matchResultData: matchResultData)
         let vc = ReviewCreateViewController(viewModel: ReviewCreateViewModel(flowType: flowType))
-        print("게임데이터\(gameData), 매치result\(matchResultData), myuserid\(myUserId)")
+        print("게임데이터\(gameData), 매치result\(matchResultData)")
         navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewModel.swift
+++ b/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewModel.swift
@@ -42,7 +42,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
         
         let showSubmitConfirm = PassthroughSubject<MatchResultData, Never>()
         
-        let navToReviewCreate = PassthroughSubject<(MatchingConfirmedGameDTO, MatchResultData, String), Never>()
+        let navToReviewCreate = PassthroughSubject<(MatchingConfirmedGameDTO, MatchResultData), Never>()
         let navToHome = PassthroughSubject<Void, Never>()
         
         let isLoading = PassthroughSubject<Bool, Never>()
@@ -124,7 +124,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
         let matchResultData = createMatchResultData()
         
         if gameData.resultStatus.isFirstSubmission {
-            output.navToReviewCreate.send((gameData, matchResultData, myProfileId))
+            output.navToReviewCreate.send((gameData, matchResultData))
         } else {
             output.showSubmitConfirm.send(matchResultData)
         }

--- a/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewModel.swift
+++ b/SMASHING/Presentation/MatchResultCreate/MatchResultCreateViewModel.swift
@@ -52,7 +52,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     // MARK: - Properties
     private let gameService: GameServiceProtocol
     private let gameData: MatchingConfirmedGameDTO
-    private let myUserId: String
+    private let myProfileId: String
     private let myNickname: String
     
     private var selectedWinner: String?
@@ -61,9 +61,9 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     let output = Output()
     
     
-    init(gameData: MatchingConfirmedGameDTO, myUserId: String, myNickname: String, gameService: GameServiceProtocol = GameService()) {
+    init(gameData: MatchingConfirmedGameDTO, myProfileId: String, myNickname: String, gameService: GameServiceProtocol = GameService()) {
         self.gameData = gameData
-        self.myUserId = myUserId
+        self.myProfileId = myProfileId
         self.myNickname = myNickname
         self.gameService = gameService
     }
@@ -124,7 +124,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
         let matchResultData = createMatchResultData()
         
         if gameData.resultStatus.isFirstSubmission {
-            output.navToReviewCreate.send((gameData, matchResultData, myUserId))
+            output.navToReviewCreate.send((gameData, matchResultData, myProfileId))
         } else {
             output.showSubmitConfirm.send(matchResultData)
         }
@@ -137,8 +137,8 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
         
         let isMyWin = (selectedWinner == myNickname)
         
-        let winnerProfileId = isMyWin ? myUserId : gameData.opponent.userID
-        let loserProfileId = isMyWin ? gameData.opponent.userID : myUserId
+        let winnerProfileId = isMyWin ? myProfileId : gameData.opponent.userID
+        let loserProfileId = isMyWin ? gameData.opponent.userID : myProfileId
         
         return MatchResultData(winnerProfileId: winnerProfileId, loserProfileId: loserProfileId)
     }
@@ -146,7 +146,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
     private var shouldPrefillResubmission: Bool {
         guard gameData.resultStatus == .resultRejected else { return false }
         guard let latestSubmitterId = gameData.latestSubmitterId else { return false }
-        return latestSubmitterId == myUserId
+        return latestSubmitterId == myProfileId
     }
     
     private func fetchSubmissionDetail(submittionId: String) {
@@ -161,7 +161,7 @@ final class MatchResultCreateViewModel: MatchResultCreateViewModelProtocol {
                 }
             } receiveValue: { [weak self] dto in
                 guard let self else { return }
-                let isMyWin = dto.winner.profileId == self.myUserId
+                let isMyWin = dto.winner.profileId == self.myProfileId
                 let winnerNickname = isMyWin ? self.myNickname : self.gameData.opponent.nickname
                 self.selectedWinner = winnerNickname
                 self.output.prefillData.send(MatchResultPrefillData(winnerNickname: winnerNickname))

--- a/SMASHING/Presentation/MatchingManage/Cells/MatchingConfirmedCell.swift
+++ b/SMASHING/Presentation/MatchingManage/Cells/MatchingConfirmedCell.swift
@@ -187,13 +187,13 @@ final class MatchingConfirmedCell: BaseUICollectionViewCell, ReuseIdentifiable {
     
     // MARK: - Configuration
     
-    func configure(with game: MatchingConfirmedGameDTO, myUserId: String) {
+    func configure(with game: MatchingConfirmedGameDTO, myProfileId: String) {
         let opponent = game.opponent
         self.nicknameLabel.text = opponent.nickname
         self.profileImageView.image = UIImage.defaultProfileImage(name: opponent.nickname)
         self.genderIconImageView.image = opponent.gender.imageSm
         self.configureTierBadge(tierCode: opponent.tierCode)
-        let isMySubmission = game.latestSubmitterId == myUserId
+        let isMySubmission = game.latestSubmitterId == myProfileId
         self.updateWriteResultButton(resultState: game.resultStatus, isMySubmission: isMySubmission)
     }
     

--- a/SMASHING/Presentation/MatchingManage/Pages/MatchingConfirmedViewController.swift
+++ b/SMASHING/Presentation/MatchingManage/Pages/MatchingConfirmedViewController.swift
@@ -15,8 +15,8 @@ final class MatchingConfirmedViewController: BaseViewController {
 
     // MARK: - Properties
     
-    private var myUserId: String {
-        return KeychainService.get(key: Environment.userIdKey) ?? ""
+    private var myProfileId: String {
+        return KeychainService.get(key: Environment.activeProfileKey) ?? ""
     }
     
     private var myNickname: String {
@@ -175,7 +175,7 @@ final class MatchingConfirmedViewController: BaseViewController {
         let viewModel = MatchResultConfirmViewModel(
             gameData: gameData,
             submissionId: submissionId,
-            myUserId: myUserId
+            myProfileId: myProfileId
         )
         let vc = MatchResultConfirmViewController(viewModel: viewModel)
         vc.hidesBottomBarWhenPushed = true
@@ -183,7 +183,7 @@ final class MatchingConfirmedViewController: BaseViewController {
     }
     
     private func showMatchResultCreate(with gameData: MatchingConfirmedGameDTO) {
-        let vm = MatchResultCreateViewModel(gameData: gameData, myUserId: myUserId, myNickname: myNickname)
+        let vm = MatchResultCreateViewModel(gameData: gameData, myProfileId: myProfileId, myNickname: myNickname)
         let vc = MatchResultCreateViewController(viewModel: vm)
         vc.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(vc, animated: true)
@@ -242,14 +242,14 @@ extension MatchingConfirmedViewController: UICollectionViewDataSource {
         }
 
         let game = self.gameList[indexPath.row]
-        cell.configure(with: game, myUserId: myUserId)
+        cell.configure(with: game, myProfileId: myProfileId)
 
         cell.onCloseTapped = { [weak self] in
             self?.closeButtonDidTap(at: indexPath.item)
         }
         cell.onAcceptTapped = { [weak self] in
             guard let self else { return }
-            let isMySubmission = game.latestSubmitterId == self.myUserId
+            let isMySubmission = game.latestSubmitterId == self.myProfileId
             let canConfirm = game.resultStatus.canConfirm(isMySubmission: isMySubmission)
             if canConfirm {
                 // 상대방이 제출한 결과 확인 플로우

--- a/SMASHING/Presentation/Profile/MyProfile/MyProfileViewModel.swift
+++ b/SMASHING/Presentation/Profile/MyProfile/MyProfileViewModel.swift
@@ -107,6 +107,7 @@ final class MyProfileViewModel: MyProfileViewModelProtocol {
             } receiveValue: { [weak self] response in
                 guard let self else { return }
                 self.storeSportsCode(from: response)
+                _ = KeychainService.add(key: Environment.activeProfileKey, value: response.activeProfile.profileId)
                 self.currentSport = response.activeProfile.sportCode
                 self.profileIdBySport = Dictionary(
                     uniqueKeysWithValues: response.allProfiles.map { ($0.sportCode, $0.profileId) }

--- a/SMASHING/Presentation/ReviewCreate/ViewModel/ReviewCreateViewModel.swift
+++ b/SMASHING/Presentation/ReviewCreate/ViewModel/ReviewCreateViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 enum ReviewFlowType {
     /// 결과 제출 플로우 (MatchResultCreate → ReviewCreate)
         /// 내가 직접 입력한 결과 + 리뷰를 함께 제출
-        case submission(gameData: MatchingConfirmedGameDTO, matchResultData: MatchResultData, myUserId: String)
+        case submission(gameData: MatchingConfirmedGameDTO, matchResultData: MatchResultData)
 
         /// 결과 확정 플로우 (MatchResultConfirm → ReviewCreate)
         /// 상대방이 제출한 결과를 확정하고 리뷰 제출
@@ -129,7 +129,7 @@ final class ReviewCreateViewModel: ReviewCreateViewModelProtocol {
     private func configureInitialData() {
         let nickname: String
                switch flowType {
-               case .submission(let gameData, _, _):
+               case .submission(let gameData, _):
                    nickname = gameData.opponent.nickname
                case .confirmation(_, _, let opponentNickname):
                    nickname = opponentNickname
@@ -140,7 +140,7 @@ final class ReviewCreateViewModel: ReviewCreateViewModelProtocol {
     
     private func submitReview() {
             switch flowType {
-            case .submission(let gameData, let matchResultData, _):
+            case .submission(let gameData, let matchResultData):
                 submitResultWithReview(gameData: gameData, matchResultData: matchResultData)
 
             case .confirmation(let gameId, let submissionId, _):


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #196 

---

## 📎 Work Description 
- 매칭 결과 제출할 때 원래 userId 기반으로 해당 매칭이 맞는지 비교를 했었는데, userId는 로그인 계정 단위의 식별자로 변경되었고, 각 스포츠별 profileId 로 구별하는 것으로 바뀌어서, 그에 따라 리팩토링을 진행했습니다.
- 추가로 현재 활성화 되어있는 `activeProfileId` 를 키체인에 저장해서 전역적으로 값을 가져다 쓸 수 있게 했습니다.

---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |


---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 사용자 식별자에서 프로필 식별자 기반 시스템으로 전환했습니다.
  * 매칭 결과 관리, 셀 구성 및 소유권 확인 로직을 프로필 ID로 업데이트했습니다.
  * 리뷰 생성 및 내비게이션 흐름에서 불필요한 사용자 ID 전달을 제거했습니다.
  * 활성 프로필 정보를 키체인에 지속 저장하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->